### PR TITLE
replace numpy and biopython by alpine packages

### DIFF
--- a/dockerfiles/dockerfile.peak_distance
+++ b/dockerfiles/dockerfile.peak_distance
@@ -4,13 +4,7 @@ LABEL tool="peak_distance"
 
 MAINTAINER Patrick Barth <patrick.barth@computational.bio.uni-giessen.de>
 
-RUN apk add --no-cache python3 python3-dev py3-pip \
-	bash \
-	gcc \
-	g++ \
-	zlib-dev \
-	&& python3 -m ensurepip  \
-	&& python3 -m pip install numpy
+RUN apk add --no-cache python3 py3-numpy bash
 
 ADD bin/wig_files_writer.py /usr/local/bin
 ADD bin/peak-distance.py /usr/local/bin

--- a/dockerfiles/dockerfile.sequence_extraction
+++ b/dockerfiles/dockerfile.sequence_extraction
@@ -4,14 +4,8 @@ LABEL tool="sequence_extraction"
 
 MAINTAINER Patrick Barth <patrick.barth@computational.bio.uni-giessen.de>
 
-RUN apk add --no-cache python3 python3-dev py3-pip \
-	bash \
-	gcc \
-	g++ \
-	zlib-dev \
-	&& python3 -m ensurepip  \
-	&& python3 -m pip install biopython \
-	&& python3 -m pip install numpy
+RUN apk add --no-cache python3 py3-numpy bash && \
+    apk add py3-biopython --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
 
 ADD bin/wig_files_writer.py /usr/local/bin
 ADD bin/extract-sequences-around-cross-link-sites.py /usr/local/bin


### PR DESCRIPTION
Use alpine packages for numpy and biopython, so we don't need to install
compilers and -dev packages.