### PR TITLE
switch to statically linked STAR binary

### DIFF
--- a/dockerfiles/dockerfile.star
+++ b/dockerfiles/dockerfile.star
@@ -5,20 +5,14 @@ LABEL tool.version="2.7.10a"
 
 MAINTAINER Patrick Barth <patrick.barth@computational.bio.uni-giessen.de>
 
-ARG TMPDIR=/opt
 ARG FILE=2.7.10a.tar.gz
 
-RUN apk update && apk add bash libgcc libstdc++ libgomp g++ wget make zlib-dev musl-dev libc-dev patch && \
-	wget -q https://github.com/alexdobin/STAR/archive/$FILE -O $TMPDIR/$FILE && \
-	tar xf $TMPDIR/$FILE -C $TMPDIR && \
-	rm $TMPDIR/$FILE && \
-	cd $TMPDIR/STAR-2.7.10a/source && \
-        wget -O - https://patch-diff.githubusercontent.com/raw/alexdobin/STAR/pull/1651.diff | patch -p 2 && \
-	make STAR && \
-    cp STAR /usr/local/bin/ && \
-    cd ../.. && rm -rf STAR-2.7.10a && \
-    apk del gcc g++ wget make zlib-dev musl-dev libc-dev patch
-
+RUN apk update && apk add bash wget && \
+	wget -q https://github.com/alexdobin/STAR/archive/$FILE && \
+	tar xzf $FILE && \
+        cp STAR-2.7.10a/bin/Linux_x86_64_static/STAR /usr/local/bin/ && \
+	rm -rf $FILE STAR-2.7.10a && \
+        apk del wget
 
 ENTRYPOINT ["STAR"]
 


### PR DESCRIPTION
A dynamically linked STAR binary fails on Alpine Linux when multiple threads are being used,
most likely due to musl instead of glibc. 

See https://github.com/alexdobin/STAR/issues/1659

For now, use the statically linked release binary.