### PR TITLE
add {e,}grep to base image

### DIFF
--- a/dockerfiles/dockerfile.base
+++ b/dockerfiles/dockerfile.base
@@ -4,4 +4,4 @@ LABEL tool="awk"
 
 MAINTAINER Patrick Barth <patrick.barth@computational.bio.uni-giessen.de>
 
-RUN apk update && apk add --no-cache gawk bash
+RUN apk update && apk add --no-cache gawk bash grep


### PR DESCRIPTION
add {e,}grep to base image so `–no-group-separators` can be used