### PR TITLE
python 3.11 upgrade

### DIFF
--- a/dockerfiles/dockerfile.checkbarcode
+++ b/dockerfiles/dockerfile.checkbarcode
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 MAINTAINER Patrick Barth <patrick.barth@computational.bio.uni-giessen.de>
 

--- a/dockerfiles/dockerfile.igvsession
+++ b/dockerfiles/dockerfile.igvsession
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 MAINTAINER Patrick Barth <patrick.barth@computational.bio.uni-giessen.de>
 


### PR DESCRIPTION
checkbarcode and igvsession upgrade to python 3.11; umi-tools needs to stay at 3.10 because compilation
fails with python 3.11; upstream issue https://github.com/CGATOxford/UMI-tools/issues/563